### PR TITLE
fix(cli): do not raise if multiple time matching images found

### DIFF
--- a/src/vr180_convert/cli.py
+++ b/src/vr180_convert/cli.py
@@ -168,14 +168,6 @@ def lr(
         ]
         if len(left_path_candidates) == 0:
             raise ValueError("No time-matched left image found")
-        if (
-            len(left_path_candidates) > 1
-            and left_path_candidates[0].stat().st_mtime
-            == left_path_candidates[1].stat().st_mtime
-        ):
-            raise ValueError(
-                f"Multiple time-matched left images found: {left_path_candidates}"
-            )
         left_path = left_path_candidates[0]
     elif not left_path.is_dir() and right_path.is_dir():
         # find closest time-matched left image
@@ -195,14 +187,6 @@ def lr(
         ]
         if len(right_path_candidates) == 0:
             raise ValueError("No time-matched right image found")
-        if (
-            len(right_path_candidates) > 1
-            and right_path_candidates[0].stat().st_mtime
-            == right_path_candidates[1].stat().st_mtime
-        ):
-            raise ValueError(
-                f"Multiple time-matched right images found: {right_path_candidates}"
-            )
         right_path = right_path_candidates[0]
     elif left_path.is_dir() and right_path.is_dir():
         raise ValueError("Both left and right paths must not be directories")


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/34j/vr180-convert/blob/main/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows [Contributing.md](https://github.com/34j/vr180-convert/blob/main/CONTRIBUTING.md)
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
